### PR TITLE
Updated Entitlement and Registration computer parameters to test for …

### DIFF
--- a/HPWarranty.psm1
+++ b/HPWarranty.psm1
@@ -54,7 +54,7 @@ Function Invoke-HPWarrantyRegistrationRequest
     Param
     (
         [Parameter(ParameterSetName = 'Default')]
-        [ValidateScript({ if ($_ -eq $env:COMPUTERNAME){ $true } else { try { Test-WSMan -ComputerName $_ -ErrorAction Stop ; $true } catch { throw "Unable to connect to WSMan on $_." } } })]
+        [ValidateScript({ if (Test-Connection -ComputerName $_ -Quiet -Count 2) { $true } })]
         [String]
         $ComputerName = $env:COMPUTERNAME,
 
@@ -201,7 +201,7 @@ Function Invoke-HPWarrantyEntitlementList
         $Token,
 
         [Parameter(ParameterSetName = 'Default')]
-        [ValidateScript({ if ($_ -eq $env:COMPUTERNAME){ $true } else { try { Test-WSMan -ComputerName $_ -ErrorAction Stop ; $true } catch { throw "Unable to connect to WSMan on $_." } } })]
+        [ValidateScript({ if (Test-Connection -ComputerName $_ -Quiet -Count 2) { $true } })]
         [String]
         $ComputerName = $env:COMPUTERNAME,
 


### PR DESCRIPTION
…connectivity not WSMan.  WSMan isn't required for these cmdlets to complete successfully and the validation scripts were breaking functionality that should otherwise work.