### PR TITLE
Proxy authentication added for SOAP request

### DIFF
--- a/HPWarranty/Private/Invoke-HPEntSOAPRequest.ps1
+++ b/HPWarranty/Private/Invoke-HPEntSOAPRequest.ps1
@@ -71,6 +71,9 @@ Function Invoke-HPEntSOAPRequest  {
     $soapWebRequest.ContentType = 'text/xml; charset=utf-8'
     $soapWebRequest.Accept = 'text/xml'
     $soapWebRequest.Method = 'POST' 
+    $proxy = [System.Net.WebRequest]::GetSystemWebProxy()
+    $proxy.Credentials = [System.Net.CredentialCache]::DefaultCredentials
+    $soapWebRequest.Proxy = $proxy
 
     try {
         $SOAPRequest.Save(

--- a/HPWarranty/Private/Invoke-HPIncSOAPRequest.ps1
+++ b/HPWarranty/Private/Invoke-HPIncSOAPRequest.ps1
@@ -39,6 +39,9 @@ Function Invoke-HPIncSOAPRequest {
     $soapWebRequest.ContentType = 'text/xml; charset=utf-8'
     $soapWebRequest.Accept = 'text/xml'
     $soapWebRequest.Method = 'POST'
+    $proxy = [System.Net.WebRequest]::GetSystemWebProxy()
+    $proxy.Credentials = [System.Net.CredentialCache]::DefaultCredentials
+    $soapWebRequest.Proxy = $proxy
 
     try {
 	    $SOAPRequest.Save(


### PR DESCRIPTION
Added system defaul proxy with default credentials property to the soapWebRequest object to allow the request forwarding through proxy.